### PR TITLE
250538: Replace hardcoded values in aso secret with values passed in from Bicep

### DIFF
--- a/infra/snd/01/kustomization.yaml
+++ b/infra/snd/01/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - platform-team-namespace.yaml
   - platform-team-aso-secret.yaml
   - ../base
 patches:

--- a/infra/snd/01/platform-team-aso-secret.yaml
+++ b/infra/snd/01/platform-team-aso-secret.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aso-credential
-  namespace: platform-team
+  namespace: flux-config
 stringData:
-  AZURE_CLIENT_ID: "cbcc2f00-8ab2-4ae4-9dba-ead1c08b3a02"
-  AZURE_SUBSCRIPTION_ID: "55f3b8c6-6800-41c7-a40d-2adb5e4e1bd1"
-  AZURE_TENANT_ID: "6f504113-6b64-43f2-ade9-242e05780007"
+  AZURE_CLIENT_ID: ${ASO_MI_CLIENTID}
+  AZURE_SUBSCRIPTION_ID: ${SUBSCRIPTION_ID}
+  AZURE_TENANT_ID: ${TENANT_ID}
   USE_WORKLOAD_IDENTITY_AUTH: "true"

--- a/infra/snd/01/platform-team-namespace.yaml
+++ b/infra/snd/01/platform-team-namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: platform-team
-  labels:
-    toolkit.fluxcd.io/tenant: platform-team

--- a/infra/snd/base/kustomization.yaml
+++ b/infra/snd/base/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - platform-team-namespace.yaml
   - ../../../core/nginx-ingress
   - ../../../core/cert-manager
   - ../../../core/azure-service-operator

--- a/infra/snd/base/kustomization.yaml
+++ b/infra/snd/base/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - platform-team-namespace.yaml
   - ../../../core/nginx-ingress
   - ../../../core/cert-manager
   - ../../../core/azure-service-operator


### PR DESCRIPTION
# **Description**
The ASO Platform secret values were initially hard-coded to get us moving.  The PR will use the values passed in via Bicep kustomization postbuild substitution variables.

The values being passed in are:

- The Platform Team ASO managed identity clientId
- subsciptionId
- tenantId

We have also removed the platform-team namespace and will use the flux-config namespace to store any ASO resources created by the Platform team identity.  This will allow us to use configmaps created by ASO is Kustomizations.  

The specific use case is:  

We need to add the clientId of the team managed identity created by ASO in the team level ASO secret in the teams namespace after the identity has been created.  This wasn't possible when the resources were created in the platform-team namespace due to cross-namespace references been blocked.  

AB#250538

# **Special notes for your reviewer**
Discussed solution with Ken and Ajay and we all agreed this gives us a way forward without the need for additional manual steps.  We also agreed it would be worthwhile revisiting this when we are more familiar with Kubernetes policies (OPA), to see if we can keep the platform-team ASO resources in it's own namespace and have a solution using policies.

# Testing
Tested in isolated cluster.  Please see screenshot of values coming through on AKS in the Kustomization.

![image](https://github.com/DEFRA/adp-infrastructure-core/assets/39670555/5bc575c7-c576-490f-8177-33bd04745e32)

![image](https://github.com/DEFRA/adp-flux-core/assets/39670555/1c7ab2cd-6585-4209-804b-cc6e5af5aeea)


# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests

