### PR TITLE
301187: Set the enable-snippets feature to true in ADP nginx

### DIFF
--- a/core/nginx-ingress/release.yaml
+++ b/core/nginx-ingress/release.yaml
@@ -51,3 +51,4 @@ spec:
       podDisruptionBudget:
         enabled: true
         annotations: {}
+      enableSnippets: true


### PR DESCRIPTION
This change has been made as it was a requirement for FCP and we should do the same for ADP.

https://dev.azure.com/defragovuk/DEFRA-FFC/_sprints/taskboard/DEFRA-FFC%20Team%20Fab/DEFRA-FFC/Platform/Fab/Sprint10?workitem=271650

[AB#271650](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/271650)

# Testing
The change has been deployed in SND1 via Flux and the setting -enable-snippets=true can be seen in the nginx-ingress-plus-controller deployment.

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYmhja3dyZTR5MzRwN3MwczQxdHFremV6bnVmZGx5ZGNqcXJmMWEydiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l4EpjKaEOvKoGt0hG/giphy.gif)
