### PR TITLE
248312: Implement Azure Kubernetes network policies with Calico (PRE) 

### DIFF
--- a/infra/pre/base/kustomization.yaml
+++ b/infra/pre/base/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - ../../../core/azure-service-operator
   - ../../../core/app-config-service
   - ../../../core/grafana
-  # - ../../../core/calico
+  - ../../../core/calico
   - priority-class.yaml
 

--- a/infra/tst/base/kustomization.yaml
+++ b/infra/tst/base/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - ../../../core/azure-service-operator
   - ../../../core/app-config-service
   - ../../../core/grafana
-  # - ../../../core/calico
+  - ../../../core/calico
   - priority-class.yaml
 


### PR DESCRIPTION
# **What this PR does / why we need it**:
This PR introduces Calico Network policies which help reduce risk of security vulnerabilities, unauthorized access, and a lack of control over network communication within the AKS cluster.

A Global Deny all ingress and egress policy has been added to the Cluster.
Then additional Allow policies have been added only were required for the Cluster and Applications to function properly.

[AB#248312](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/248312)

# Testing
Tested against SND1 ensuring Cluster and Applications are still functioning as normal after Network policies have been applied.  

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYmR5YmhtY3h5Znpnbm9lNjg5OW91MDVtcWt3YTZ0bnY4a3A0enUzbiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/u3jMHijwoCBaORpGeX/giphy.gif)
