### PR TITLE
248312: Use latest Network Policy helm chart and also deploy to Test

### DIFF
--- a/core/calico/api-server-release.yaml
+++ b/core/calico/api-server-release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: adp-calico-helm-chart
-      version: "0.1.0"
+      version: "0.1.1"
       sourceRef:
         kind: HelmRepository
         name: repository-adp-calico-helm-chart

--- a/core/calico/network-policies-release.yaml
+++ b/core/calico/network-policies-release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: adp-calico-helm-chart
-      version: "0.1.0"
+      version: "0.1.1"
       sourceRef:
         kind: HelmRepository
         name: repository-adp-calico-helm-chart

--- a/infra/tst/base/kustomization.yaml
+++ b/infra/tst/base/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - ../../../core/azure-service-operator
   - ../../../core/app-config-service
   - ../../../core/grafana
-  # - ../../../core/calico
+  - ../../../core/calico
   - priority-class.yaml
 


### PR DESCRIPTION
We have noticed the following error in the logs and the Calico-ApiServer pods intermittently going into a crash loop backoff.

```
W0226 10:26:01.961415       1 dispatcher.go:176] Failed calling webhook, failing open validation.gatekeeper.sh: failed calling webhook "validation.gatekeeper.sh": failed to call webhook: Post "https://gatekeeper-webhook-service.gatekeeper-system.svc:443/v1/admit?timeout=3s": context deadline exceeded
E0226 10:26:01.961454       1 dispatcher.go:183] failed calling webhook "validation.gatekeeper.sh": failed to call webhook: Post "https://gatekeeper-webhook-service.gatekeeper-system.svc:443/v1/admit?timeout=3s": context deadline exceeded
```

We have added a network policy to the latest version of the Calico Helm chart.  This PR will also deploy to the Test environment.

# Testing
Changes tested in Dev successfully.

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
