### PR TITLE
333875: Fix pod disruption budgets for PRE and PRD deployments

### DIFF
--- a/infra/prd/01/nginx-ingress-values.yaml
+++ b/infra/prd/01/nginx-ingress-values.yaml
@@ -17,7 +17,7 @@ spec:
       image:
         repository: "${SHARED_CONTAINER_REGISTRY}.azurecr.io/image/nginx-plus-ingress"
         tag: 3.3.1
+      replicaCount: 3
       podDisruptionBudget:
         minAvailable: 2
-        disruptionsAllowed: 1
 

--- a/infra/pre/01/nginx-ingress-values.yaml
+++ b/infra/pre/01/nginx-ingress-values.yaml
@@ -17,7 +17,8 @@ spec:
       image:
         repository: "${SHARED_CONTAINER_REGISTRY}.azurecr.io/image/nginx-plus-ingress"
         tag: 3.3.1
+      replicaCount: 3
       podDisruptionBudget:
         minAvailable: 2
-        disruptionsAllowed: 1
+
 


### PR DESCRIPTION
# **What this PR does / why we need it**:
The POD disruption budgets needed to be updated to be inline with the lower environments.  We were getting the following error in the PRE deployment:

_Drain node aks-npsystem01-25540822-vmss000000 failed when evicting pod nginx-ingress-plus-controller-6b749bcdd8-8m67c. Eviction failed with Too many Requests error. This is often caused by a restrictive Pod Disruption Budget (PDB) policy. See http://aka.ms/aks/debugdrainfailures. Original error: API call to Kubernetes API Server failed._


[AB#333875](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/333875)

# **Special notes for your reviewer**

# Testing
Previously tested in all lower environments

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
