### PR TITLE
354658: Send notifications to second event hub for SND1 and SND4

### DIFF
--- a/services/base/repository.yaml
+++ b/services/base/repository.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   interval: 5m
   ref:
-    branch: main
+    branch: aa/sendFluxNotificationsTo2EventHubs
   url: ssh://git@github.com/DEFRA/adp-flux-services/
   secretRef:
     name: adp-platform-secrets

--- a/services/base/repository.yaml
+++ b/services/base/repository.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   interval: 5m
   ref:
-    branch: aa/sendFluxNotificationsTo2EventHubs
+    branch: main
   url: ssh://git@github.com/DEFRA/adp-flux-services/
   secretRef:
     name: adp-platform-secrets

--- a/services/snd/01/config-provider-second-event-hub.yaml
+++ b/services/snd/01/config-provider-second-event-hub.yaml
@@ -1,0 +1,25 @@
+apiVersion: azconfig.io/v1
+kind: AzureAppConfigurationProvider
+metadata:
+  name: adp-platform-second-eventhub
+  namespace: flux-config
+spec:
+  endpoint: https://${APPCONFIG_NAME}.azconfig.io
+  target:
+    configMapName: adp-platform-second-eventhub
+  auth:
+    workloadIdentity:
+      managedIdentityClientId: ${APPCONFIG_MI_CLIENTID}
+  configuration:
+    selectors:
+      - keyFilter: "address"
+        labelFilter: adp-platform-secondary-eventhub
+  secret:
+    target:
+      secretName: adp-platform-second-eventhub-secret
+    auth:
+      workloadIdentity:
+        managedIdentityClientId: ${APPCONFIG_MI_CLIENTID}
+    refresh:
+      interval: 5m
+      enabled: true

--- a/services/snd/01/kustomization.yaml
+++ b/services/snd/01/kustomization.yaml
@@ -5,3 +5,4 @@ metadata:
 resources: 
   - ../../base
   - services.yaml
+  - config-provider-second-event-hub.yaml

--- a/services/snd/04/config-provider-second-event-hub.yaml
+++ b/services/snd/04/config-provider-second-event-hub.yaml
@@ -1,0 +1,25 @@
+apiVersion: azconfig.io/v1
+kind: AzureAppConfigurationProvider
+metadata:
+  name: adp-platform-second-eventhub
+  namespace: flux-config
+spec:
+  endpoint: https://${APPCONFIG_NAME}.azconfig.io
+  target:
+    configMapName: adp-platform-second-eventhub
+  auth:
+    workloadIdentity:
+      managedIdentityClientId: ${APPCONFIG_MI_CLIENTID}
+  configuration:
+    selectors:
+      - keyFilter: "address"
+        labelFilter: adp-platform-secondary-eventhub
+  secret:
+    target:
+      secretName: adp-platform-second-eventhub-secret
+    auth:
+      workloadIdentity:
+        managedIdentityClientId: ${APPCONFIG_MI_CLIENTID}
+    refresh:
+      interval: 5m
+      enabled: true

--- a/services/snd/04/kustomization.yaml
+++ b/services/snd/04/kustomization.yaml
@@ -5,3 +5,4 @@ metadata:
 resources: 
   - ../../base
   - services.yaml
+  - config-provider-second-event-hub.yaml


### PR DESCRIPTION
# **What this PR does / why we need it**:
There is a requirement to send flux notifications from SND4 to both PRE and PRD.  This is to allow us to test any changes made to the Flux Notification Service in another environment (PRE) in the DEFRA tenant prior to deploying to Production.  To also have the same setup in the DefraDev tenant SND1 will send notifications to both DEV and TST.

This PR will create a secret 'adp-platform-second-eventhub-secret' using the AzureAppConfigurationProvider.  It will reference a key 'address' using the label 'adp-platform-secondary-eventhub'.  This secret is required because we already have a secret with the key 'address' used by the first event hub configuration.

https://fluxcd.io/flux/components/notification/providers/#sas-based-auth

[AB#354658](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/354658)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
![image](https://github.com/DEFRA/adp-flux-core/assets/39670555/986684d7-5722-4669-9262-f92effd8a619)

![image](https://github.com/DEFRA/adp-flux-core/assets/39670555/b8bd2095-650e-4f08-9b57-0b9b41ab4c36)


# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
