### PR TITLE
Add healthz probe to ingress-nginx

### DIFF
--- a/core/ingress-nginx/release.yaml
+++ b/core/ingress-nginx/release.yaml
@@ -31,6 +31,7 @@ spec:
           service.beta.kubernetes.io/azure-load-balancer-internal: "true"
           service.beta.kubernetes.io/azure-pls-create: "true"
           service.beta.kubernetes.io/azure-pls-name: "aks-loadbalancer-pls"
+          service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"
         internal:
           enabled: true
           type: LoadBalancer


### PR DESCRIPTION
Tested in FCP already. Required for the internal load balancer to pass health checks. 

# **What this PR does / why we need it**:
Adds annotation to ingress-nginx deployment. 

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [ ] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [ ] Title pattern should be `{work item number}: {title}`
- [ ] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
